### PR TITLE
docs: Change default status for Android release to 'completed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ steps:
     publish-distributor: 'android-google-play'
     # Android
     publish-android-fastlane-secrets-json-base64: ${{ secrets.ANDROID_GOOGLE_PLAY_JSON }}
-    publish-android-release-status: ${{ secrets.ANDROID_RELEASE_STATUS }}
+    publish-android-release-status: 'completed' # Optional, default: 'draft'. You need to have released an alpha version for `completed` status to work: https://github.com/fastlane/fastlane/discussions/18293
     android-keystore-file-base64: ${{ secrets.ANDROID_KEYSTORE }}
     android-keystore-password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
     android-key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}


### PR DESCRIPTION
Updated the default value for publish-android-release-status to 'completed' and added a note about alpha version release.